### PR TITLE
feat: simplify the construction of `Result` type

### DIFF
--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -858,7 +858,7 @@ Result<FSMWithStartEnd> FSMWithStartEnd::Intersect(
     const FSMWithStartEnd& lhs, const FSMWithStartEnd& rhs, int num_of_states_limited
 ) {
   if (!lhs.IsLeaf() || !rhs.IsLeaf()) {
-    return Result<FSMWithStartEnd>::Err("Intersect only support leaf fsm!");
+    return ResultErr("Intersect only support leaf fsm!");
   }
   auto lhs_dfa = lhs.ToDFA();
   auto rhs_dfa = rhs.ToDFA();
@@ -907,7 +907,7 @@ Result<FSMWithStartEnd> FSMWithStartEnd::Intersect(
   state_map[{lhs_dfa.GetStart(), rhs_dfa.GetStart()}] = 0;
   while (!queue.empty()) {
     if (int(state_map.size()) > num_of_states_limited) {
-      return Result<FSMWithStartEnd>::Err("Intersection have too many states!");
+      return ResultErr("Intersection have too many states!");
     }
     auto state = queue.front();
     queue.pop();
@@ -980,7 +980,7 @@ Result<FSMWithStartEnd> FSMWithStartEnd::Intersect(
       result.AddEndState(state_map[state]);
     }
   }
-  return Result<FSMWithStartEnd>::Ok(result);
+  return ResultOk(result);
 }
 
 bool FSMWithStartEnd::IsDFA() {

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -16,7 +16,6 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <variant>
 #include <vector>
 
 #include "../cpp/support/csr_array.h"

--- a/cpp/fsm_builder.cc
+++ b/cpp/fsm_builder.cc
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <set>
 #include <stack>
+#include <type_traits>
 #include <unordered_set>
 #include <variant>
 #include <vector>
@@ -98,6 +99,11 @@ class RegexIR {
 
   Result<FSMWithStartEnd> visit(const LookAhead& state) const;
 
+  template <typename T, typename = std::enable_if_t<std::is_same_v<State, T>>>
+  Result<FSMWithStartEnd> visit(const T& state) const {
+    return std::visit([&](auto&& arg) { return visit(arg); }, state);
+  }
+
  private:
   /*!
    * \brief Construct a FSM from a regex string.
@@ -129,7 +135,7 @@ class RegexIR {
 
 Result<std::pair<int, int>> RegexIR::CheckRepeat(const std::string& regex, int& start) {
   if (regex[start] != '{') {
-    return Result<std::pair<int, int>>::Err("Invalid repeat format1");
+    return ResultErr("Invalid repeat format1");
   }
   int lower_bound = 0;
   int upper_bound = RegexIR::kRepeatNoUpperBound;
@@ -144,7 +150,7 @@ Result<std::pair<int, int>> RegexIR::CheckRepeat(const std::string& regex, int& 
     start++;
   }
   if (num_str.empty()) {
-    return Result<std::pair<int, int>>::Err("Invalid repeat format2");
+    return ResultErr("Invalid repeat format2");
   }
   lower_bound = std::stoi(num_str);
   while (static_cast<size_t>(start) < regex.size() && regex[start] == ' ') {
@@ -153,10 +159,10 @@ Result<std::pair<int, int>> RegexIR::CheckRepeat(const std::string& regex, int& 
   // The format is {n}
   if (regex[start] == '}') {
     upper_bound = lower_bound;
-    return Result<std::pair<int, int>>::Ok(std::make_pair(lower_bound, upper_bound));
+    return ResultOk(std::make_pair(lower_bound, upper_bound));
   }
   if (regex[start] != ',') {
-    return Result<std::pair<int, int>>::Err("Invalid repeat format3");
+    return ResultErr("Invalid repeat format3");
   }
   XGRAMMAR_DCHECK(regex[start] == ',');
   start++;
@@ -165,7 +171,7 @@ Result<std::pair<int, int>> RegexIR::CheckRepeat(const std::string& regex, int& 
   }
   // The format is {n,}
   if (regex[start] == '}') {
-    return Result<std::pair<int, int>>::Ok(std::make_pair(lower_bound, upper_bound));
+    return ResultOk(std::make_pair(lower_bound, upper_bound));
   }
   num_str.clear();
   while (static_cast<size_t>(start) < regex.size() && std::isdigit(regex[start])) {
@@ -173,80 +179,70 @@ Result<std::pair<int, int>> RegexIR::CheckRepeat(const std::string& regex, int& 
     start++;
   }
   if (num_str.empty()) {
-    return Result<std::pair<int, int>>::Err("Invalid repeat format4");
+    return ResultErr("Invalid repeat format4");
   }
   upper_bound = std::stoi(num_str);
   while (static_cast<size_t>(start) < regex.size() && regex[start] == ' ') {
     start++;
   }
   if (regex[start] != '}') {
-    return Result<std::pair<int, int>>::Err("Invalid repeat format5");
+    return ResultErr("Invalid repeat format5");
   }
   XGRAMMAR_DCHECK(regex[start] == '}');
-  return Result<std::pair<int, int>>::Ok(std::make_pair(lower_bound, upper_bound));
+  return ResultOk(std::make_pair(lower_bound, upper_bound));
 }
 
 Result<FSMWithStartEnd> RegexIR::Build() const {
   if (states.empty()) {
     FSM empty_fsm(1);
     FSMWithStartEnd result(empty_fsm, 0, std::unordered_set<int>{0}, false);
-    return Result<FSMWithStartEnd>::Ok(std::move(result));
+    return ResultOk(std::move(result));
   }
   std::vector<FSMWithStartEnd> fsm_list;
   for (const auto& state : states) {
-    auto visited = std::visit([&](auto&& arg) { return visit(arg); }, state);
-    if (visited.IsErr()) {
-      return visited;
-    }
-    fsm_list.push_back(visited.Unwrap());
+    UNWRAP_OR_RETURN(visited, visit(state));
+    fsm_list.push_back(visited);
   }
   if (fsm_list.size() > 1) {
-    return Result<FSMWithStartEnd>::Ok(FSMWithStartEnd::Concat(fsm_list));
+    return ResultOk(FSMWithStartEnd::Concat(fsm_list));
   } else {
     // If there is only one FSM, return it directly.
-    return Result<FSMWithStartEnd>::Ok(std::move(fsm_list[0]));
+    return ResultOk(std::move(fsm_list[0]));
   }
 }
 
 Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Leaf& state) const {
   FSMWithStartEnd result = BuildLeafFSMFromRegex(state.regex);
-  return Result<FSMWithStartEnd>::Ok(std::move(result));
+  return ResultOk(std::move(result));
 }
 
 Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Union& state) const {
   std::vector<FSMWithStartEnd> fsm_list;
   for (const auto& child : state.states) {
-    auto visited = std::visit([&](auto&& arg) { return RegexIR::visit(arg); }, child);
-    if (visited.IsErr()) {
-      return visited;
-    }
-    fsm_list.push_back(visited.Unwrap());
+    UNWRAP_OR_RETURN(visited, visit(child));
+    fsm_list.push_back(visited);
   }
   if (fsm_list.size() <= 1) {
-    return Result<FSMWithStartEnd>::Err("Invalid union");
+    return ResultErr("Invalid union");
   }
-  return Result<FSMWithStartEnd>::Ok(FSMWithStartEnd::Union(fsm_list));
+  return ResultOk(FSMWithStartEnd::Union(fsm_list));
 }
 
 Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Symbol& state) const {
   if (state.state.size() != 1) {
-    return Result<FSMWithStartEnd>::Err("Invalid symbol");
+    return ResultErr("Invalid symbol");
   }
-  Result<FSMWithStartEnd> child =
-      std::visit([&](auto&& arg) { return RegexIR::visit(arg); }, state.state[0]);
-  if (child.IsErr()) {
-    return child;
-  }
+  UNWRAP_OR_RETURN(child, visit(state.state[0]));
 
   switch (state.symbol) {
     case RegexIR::RegexSymbol::plus: {
-      return Result<FSMWithStartEnd>::Ok(child.Unwrap().Plus());
+      return ResultOk(child.Plus());
     }
     case RegexIR::RegexSymbol::star: {
-      return Result<FSMWithStartEnd>::Ok(child.Unwrap().Star());
+      return ResultOk(child.Star());
     }
     case RegexIR::RegexSymbol::optional: {
-      return Result<FSMWithStartEnd>::Ok(child.Unwrap().Optional());
+      return ResultOk(child.Optional());
     }
     default: {
       XGRAMMAR_LOG(FATAL) << "Unknown regex symbol: " << static_cast<int>(state.symbol);
@@ -257,28 +253,21 @@ Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Symbol& state) const {
 Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Bracket& state) const {
   std::vector<FSMWithStartEnd> fsm_list;
   for (const auto& child : state.states) {
-    auto visited = std::visit([&](auto&& arg) { return RegexIR::visit(arg); }, child);
-    if (visited.IsErr()) {
-      return visited;
-    }
-    fsm_list.push_back(visited.Unwrap());
+    UNWRAP_OR_RETURN(visited, visit(child));
+    fsm_list.push_back(visited);
   }
   if (fsm_list.empty()) {
-    return Result<FSMWithStartEnd>::Err("Invalid bracket");
+    return ResultErr("Invalid bracket");
   }
-  return Result<FSMWithStartEnd>::Ok(FSMWithStartEnd::Concat(fsm_list));
+  return ResultOk(FSMWithStartEnd::Concat(fsm_list));
 }
 
 Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Repeat& state) const {
   if (state.states.size() != 1) {
-    return Result<FSMWithStartEnd>::Err("Invalid repeat");
+    return ResultErr("Invalid repeat");
   }
-  Result<FSMWithStartEnd> child =
-      std::visit([&](auto&& arg) { return RegexIR::visit(arg); }, state.states[0]);
-  if (child.IsErr()) {
-    return child;
-  }
-  FSMWithStartEnd result = child.Unwrap();
+  UNWRAP_OR_RETURN(child, visit(state.states[0]));
+  FSMWithStartEnd result = child;
   std::unordered_set<int> new_ends;
 
   if (state.lower_bound == 1) {
@@ -289,18 +278,18 @@ Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Repeat& state) const {
   // Handling {n,}
   if (state.upper_bound == RegexIR::kRepeatNoUpperBound) {
     for (int i = 2; i < state.lower_bound; i++) {
-      result = FSMWithStartEnd::Concat(std::vector<FSMWithStartEnd>{result, child.Unwrap()});
+      result = FSMWithStartEnd::Concat(std::vector<FSMWithStartEnd>{result, child});
     }
     int end_state_of_lower_bound_fsm = *result.GetEnds().begin();
-    result = FSMWithStartEnd::Concat(std::vector<FSMWithStartEnd>{result, child.Unwrap()});
+    result = FSMWithStartEnd::Concat(std::vector<FSMWithStartEnd>{result, child});
     for (const auto& end : result.GetEnds()) {
       result->AddEpsilonEdge(end, end_state_of_lower_bound_fsm);
     }
-    return Result<FSMWithStartEnd>::Ok(std::move(result));
+    return ResultOk(std::move(result));
   }
   // Handling {n, m} or {n}
   for (int i = 2; i <= state.upper_bound; i++) {
-    result = FSMWithStartEnd::Concat(std::vector<FSMWithStartEnd>{result, child.Unwrap()});
+    result = FSMWithStartEnd::Concat(std::vector<FSMWithStartEnd>{result, child});
     if (i >= state.lower_bound) {
       for (const auto& end : result.GetEnds()) {
         new_ends.insert(end);
@@ -310,7 +299,7 @@ Result<FSMWithStartEnd> RegexIR::visit(const RegexIR::Repeat& state) const {
   for (const auto& end : new_ends) {
     result.AddEndState(end);
   }
-  return Result<FSMWithStartEnd>::Ok(std::move(result));
+  return ResultOk(std::move(result));
 }
 
 FSMWithStartEnd RegexIR::BuildLeafFSMFromRegex(const std::string& regex) {
@@ -548,14 +537,14 @@ Result<FSMWithStartEnd> RegexFSMBuilder::Build(const std::string& regex) {
     // Handle The class.
     if (regex[i] == '[') {
       if (left_middle_bracket != -1) {
-        return Result<FSMWithStartEnd>::Err("Nested middle bracket!");
+        return ResultErr("Nested middle bracket!");
       }
       left_middle_bracket = i;
       continue;
     }
     if (regex[i] == ']') {
       if (left_middle_bracket == -1) {
-        return Result<FSMWithStartEnd>::Err("Invalid middle bracket!");
+        return ResultErr("Invalid middle bracket!");
       }
       RegexIR::Leaf leaf;
       leaf.regex = regex.substr(left_middle_bracket, i - left_middle_bracket + 1);
@@ -571,11 +560,11 @@ Result<FSMWithStartEnd> RegexFSMBuilder::Build(const std::string& regex) {
     }
     if (regex[i] == '+' || regex[i] == '*' || regex[i] == '?') {
       if (stack.empty()) {
-        return Result<FSMWithStartEnd>::Err("Invalid regex: no state before operator!");
+        return ResultErr("Invalid regex: no state before operator!");
       }
       auto state = stack.top();
       if (std::holds_alternative<char>(state)) {
-        return Result<FSMWithStartEnd>::Err("Invalid regex: no state before operator!");
+        return ResultErr("Invalid regex: no state before operator!");
       }
       stack.pop();
       auto child = std::get<RegexIR::State>(state);
@@ -635,9 +624,7 @@ Result<FSMWithStartEnd> RegexFSMBuilder::Build(const std::string& regex) {
         }
       }
       if (!paired) {
-        return Result<FSMWithStartEnd>::Err(
-            "Invalid regex: no paired bracket!" + std::to_string(__LINE__)
-        );
+        return ResultErr("Invalid regex: no paired bracket!" + std::to_string(__LINE__));
       }
       if (states.empty()) {
         continue;
@@ -664,18 +651,14 @@ Result<FSMWithStartEnd> RegexFSMBuilder::Build(const std::string& regex) {
               bracket.states.clear();
               continue;
             }
-            return Result<FSMWithStartEnd>::Err(
-                "Invalid regex: no paired bracket!" + std::to_string(__LINE__)
-            );
+            return ResultErr("Invalid regex: no paired bracket!" + std::to_string(__LINE__));
           }
           if (std::holds_alternative<RegexIR::State>(state)) {
             auto child = std::get<RegexIR::State>(state);
             bracket.states.push_back(child);
             continue;
           }
-          return Result<FSMWithStartEnd>::Err(
-              "Invalid regex: no paired bracket!" + std::to_string(__LINE__)
-          );
+          return ResultErr("Invalid regex: no paired bracket!" + std::to_string(__LINE__));
         }
         union_state.states.push_back(bracket);
         stack.push(union_state);
@@ -684,21 +667,18 @@ Result<FSMWithStartEnd> RegexFSMBuilder::Build(const std::string& regex) {
     }
     if (regex[i] == '{') {
       if (stack.empty()) {
-        return Result<FSMWithStartEnd>::Err("Invalid regex: no state before repeat!");
+        return ResultErr("Invalid regex: no state before repeat!");
       }
       auto state = stack.top();
       if (std::holds_alternative<char>(state)) {
-        return Result<FSMWithStartEnd>::Err("Invalid regex: no state before repeat!");
+        return ResultErr("Invalid regex: no state before repeat!");
       }
       stack.pop();
-      auto bounds_result = RegexIR::CheckRepeat(regex, i);
-      if (bounds_result.IsErr()) {
-        return Result<FSMWithStartEnd>::Err(bounds_result.UnwrapErr());
-      }
+      UNWRAP_OR_RETURN(bounds_result, RegexIR::CheckRepeat(regex, i));
       auto child = std::get<RegexIR::State>(state);
       RegexIR::Repeat repeat;
-      repeat.lower_bound = bounds_result.Unwrap().first;
-      repeat.upper_bound = bounds_result.Unwrap().second;
+      repeat.lower_bound = bounds_result.first;
+      repeat.upper_bound = bounds_result.second;
       repeat.states.push_back(child);
       stack.push(repeat);
       continue;
@@ -726,7 +706,7 @@ Result<FSMWithStartEnd> RegexFSMBuilder::Build(const std::string& regex) {
         stack.pop();
         continue;
       }
-      return Result<FSMWithStartEnd>::Err("Invalid regex: no paired!");
+      return ResultErr("Invalid regex: no paired!");
     }
     auto state = stack.top();
     stack.pop();

--- a/cpp/json_schema_converter.cc
+++ b/cpp/json_schema_converter.cc
@@ -314,6 +314,18 @@ class JSONSchemaConverter {
     picojson::value additional_item_schema;
     int min_items;
     int max_items;
+    ArraySpec(
+        std::vector<picojson::value> prefix_item_schemas_,
+        bool allow_additional_items_,
+        picojson::value additional_item_schema_,
+        int min_items_ = 0,
+        int max_items_ = INT_MAX
+    )
+        : prefix_item_schemas(std::move(prefix_item_schemas_)),
+          allow_additional_items(allow_additional_items_),
+          additional_item_schema(std::move(additional_item_schema_)),
+          min_items(min_items_),
+          max_items(max_items_) {}
   };
 
   Result<ArraySpec, SchemaError> ParseArraySchema(const picojson::object& schema);
@@ -1962,7 +1974,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
 
   if (schema.count("prefixItems")) {
     if (!schema.at("prefixItems").is<picojson::array>()) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "prefixItems must be an array"
       );
     }
@@ -1970,12 +1982,12 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
     for (const auto& item : prefix_item_schemas) {
       if (item.is<bool>()) {
         if (!item.get<bool>()) {
-          return Result<ArraySpec, SchemaError>::Err(
+          return ResultErr<SchemaError>(
               SchemaErrorType::kUnsatisfiableSchema, "prefixItems contains false"
           );
         }
       } else if (!item.is<picojson::object>()) {
-        return Result<ArraySpec, SchemaError>::Err(
+        return ResultErr<SchemaError>(
             SchemaErrorType::kInvalidSchema, "prefixItems must be an array of objects or booleans"
         );
       }
@@ -1985,7 +1997,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
   if (schema.count("items")) {
     auto items_value = schema.at("items");
     if (!items_value.is<bool>() && !items_value.is<picojson::object>()) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "items must be a boolean or an object"
       );
     }
@@ -1998,7 +2010,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
   } else if (schema.count("unevaluatedItems")) {
     auto unevaluated_items_value = schema.at("unevaluatedItems");
     if (!unevaluated_items_value.is<bool>() && !unevaluated_items_value.is<picojson::object>()) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "unevaluatedItems must be a boolean or an object"
       );
     }
@@ -2017,16 +2029,14 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
 
   if (schema.count("minItems")) {
     if (!schema.at("minItems").is<int64_t>()) {
-      return Result<ArraySpec, SchemaError>::Err(
-          SchemaErrorType::kInvalidSchema, "minItems must be an integer"
-      );
+      return ResultErr<SchemaError>(SchemaErrorType::kInvalidSchema, "minItems must be an integer");
     }
     min_items = std::max(0, static_cast<int>(schema.at("minItems").get<int64_t>()));
   }
 
   if (schema.count("minContains")) {
     if (!schema.at("minContains").is<int64_t>()) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "minContains must be an integer"
       );
     }
@@ -2035,7 +2045,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
 
   if (schema.count("maxItems")) {
     if (!schema.at("maxItems").is<int64_t>() || schema.at("maxItems").get<int64_t>() < 0) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kInvalidSchema, "maxItems must be a non-negative integer"
       );
     }
@@ -2044,7 +2054,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
 
   // Check if the schema is unsatisfiable
   if (max_items != -1 && min_items > max_items) {
-    return Result<ArraySpec, SchemaError>::Err(
+    return ResultErr<SchemaError>(
         SchemaErrorType::kUnsatisfiableSchema,
         "minItems is greater than maxItems: " + std::to_string(min_items) + " > " +
             std::to_string(max_items)
@@ -2052,7 +2062,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
   }
 
   if (max_items != -1 && max_items < static_cast<int>(prefix_item_schemas.size())) {
-    return Result<ArraySpec, SchemaError>::Err(
+    return ResultErr<SchemaError>(
         SchemaErrorType::kUnsatisfiableSchema,
         "maxItems is less than the number of prefixItems: " + std::to_string(max_items) + " < " +
             std::to_string(prefix_item_schemas.size())
@@ -2062,7 +2072,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
   if (!allow_additional_items) {
     // [len, len] must be in [min, max]
     if (static_cast<int>(prefix_item_schemas.size()) < min_items) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kUnsatisfiableSchema,
           "minItems is greater than the number of prefixItems, but additional items are not "
           "allowed: " +
@@ -2070,7 +2080,7 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
       );
     }
     if (max_items != -1 && static_cast<int>(prefix_item_schemas.size()) > max_items) {
-      return Result<ArraySpec, SchemaError>::Err(
+      return ResultErr<SchemaError>(
           SchemaErrorType::kUnsatisfiableSchema,
           "maxItems is less than the number of prefixItems, but additional items are not "
           "allowed: " +
@@ -2079,9 +2089,9 @@ Result<JSONSchemaConverter::ArraySpec, SchemaError> JSONSchemaConverter::ParseAr
     }
   }
 
-  return Result<ArraySpec, SchemaError>::Ok(ArraySpec{
+  return ResultOk<ArraySpec>(
       prefix_item_schemas, allow_additional_items, additional_item_schema, min_items, max_items
-  });
+  );
 }
 
 std::string JSONSchemaConverter::VisitArray(

--- a/cpp/support/utils.h
+++ b/cpp/support/utils.h
@@ -9,9 +9,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <iterator>
-#include <memory>
 #include <optional>
+#include <stdexcept>
 #include <tuple>
 #include <type_traits>
 #include <unordered_set>
@@ -101,6 +100,28 @@ class TypedError : public std::runtime_error {
   T type_;
 };
 
+template <typename T, bool IsOk>
+struct PartialResult {
+  template <typename... Args>
+  PartialResult(Args&&... args) : value(std::forward<Args>(args)...) {}
+  T value;
+};
+
+template <typename E = std::runtime_error, typename..., typename... Args>
+inline PartialResult<E, false> ResultErr(Args&&... args) {
+  return PartialResult<E, false>{std::forward<Args>(args)...};
+}
+
+template <typename T, typename..., typename... Args>
+inline PartialResult<T, true> ResultOk(Args&&... args) {
+  return PartialResult<T, true>{std::forward<Args>(args)...};
+}
+
+template <typename T>
+inline PartialResult<T&&, true> ResultOk(T&& value) {
+  return PartialResult<T&&, true>{std::forward<T>(value)};
+}
+
 /*!
  * \brief A Result type similar to Rust's Result, representing either success (Ok) or failure (Err).
  * \tparam T The type of the success value
@@ -109,21 +130,22 @@ template <typename T, typename E = std::runtime_error>
 class Result {
  private:
   static_assert(!std::is_same_v<T, E>, "T and E cannot be the same type");
+  using OkTag = std::in_place_type_t<T>;
+  using ErrTag = std::in_place_type_t<E>;
 
  public:
-  /*! \brief Construct a success Result with a const reference */
-  static Result Ok(const T& value) { return Result(value); }
-  /*! \brief Construct a success Result with a move */
-  static Result Ok(T&& value) { return Result(std::move(value)); }
+  Result() = delete;
 
-  /*! \brief Construct an error Result with a const reference */
-  static Result Err(const E& error) { return Result(error); }
-  /*! \brief Construct an error Result with a move */
-  static Result Err(E&& error) { return Result(std::move(error)); }
-  /*! \brief Forward constructor for error type */
-  template <typename... Args>
-  static Result Err(Args&&... args) {
-    return Result(E(std::forward<Args>(args)...));
+  // This can only be the chain result of calling ResultErr
+  template <typename E2>
+  Result(PartialResult<E2, false>&& other) : data_(ErrTag{}, std::forward<E2>(other.value)) {
+    static_assert(std::is_same_v<std::decay_t<E2>, E>, "Error type mismatch");
+  }
+
+  // This can only be the chain result of calling ResultOk
+  template <typename T2>
+  Result(PartialResult<T2, true>&& other) : data_(OkTag{}, std::forward<T2>(other.value)) {
+    static_assert(std::is_same_v<std::decay_t<T2>, T>, "Success type mismatch");
   }
 
   /*! \brief Check if Result contains success value */
@@ -208,13 +230,15 @@ class Result {
   }
 
  private:
-  explicit Result(const T& value) : data_(value) {}
-  explicit Result(T&& value) : data_(std::move(value)) {}
-  explicit Result(const E& err) : data_(err) {}
-  explicit Result(E&& err) : data_(std::move(err)) {}
-
   std::variant<T, E> data_;
 };
+
+#define UNWRAP_OR_RETURN(variable, result)     \
+  auto&& _##variable = (result);               \
+  if (_##variable.IsErr()) {                   \
+    return ResultErr(_##variable.UnwrapErr()); \
+  }                                            \
+  auto variable = std::move(_##variable).Unwrap();
 
 }  // namespace xgrammar
 


### PR DESCRIPTION
1. Use `ResultOk` and `ResultErr` to replace `Result<..., ...>::Ok` and `Result<...,...>::Err`
2. Add `UNWRAP_OR_RETURN` macro to simply the control flow (if result is err, just simply pass on the error as return value) 