### PR TITLE
feat: add Token() grammar construct with kTokenSet/kTokenExclude FSM edges

### DIFF
--- a/cpp/earley_parser.cc
+++ b/cpp/earley_parser.cc
@@ -198,6 +198,9 @@ std::pair</* scanable */ bool, /* completable */ bool> EarleyParser::Predict(
     case GrammarExprType::kCharacterClass: {
       return std::make_pair(true, false);  // The element is scanable, but not completable.
     }
+    case GrammarExprType::kTokenSet: {
+      return std::make_pair(false, false);
+    }
     default: {
       XGRAMMAR_LOG(FATAL) << "The element type is not supported! The type is: "
                           << int(element_expr.type);
@@ -888,6 +891,55 @@ void EarleyParser::AdvanceFsm(const ParserState& state, const uint8_t ch) {
       Enqueue(std::move(new_state));
     }
   }
+}
+
+void EarleyParser::ScanAtomicToken(const ParserState& state, int32_t token_id) {
+  if (state.rule_id == -1) return;
+  XGRAMMAR_DCHECK(grammar_->per_rule_fsms[state.rule_id].has_value());
+  const auto& current_fsm = grammar_->per_rule_fsms[state.rule_id].value();
+  for (const auto& edge : current_fsm.GetFsm().GetEdges(state.element_id)) {
+    if (!edge.IsTokenSet()) continue;
+    auto info = current_fsm.GetFsm().GetTokenSetEdgeInfo(edge.GetAuxIndex());
+    if (!info.Contains(token_id)) continue;
+    auto new_state = state;
+    new_state.element_id = edge.target;
+    if ((!current_fsm.IsNonTerminalState(edge.target)) &&
+        (!current_fsm.IsEndState(edge.target) && current_fsm.IsScanableState(edge.target))) {
+      EnqueueWithoutProcessing(std::move(new_state));
+    } else {
+      Enqueue(std::move(new_state));
+    }
+  }
+}
+
+bool EarleyParser::AdvanceToken(int32_t token_id, bool debug_print) {
+  XGRAMMAR_DCHECK(tmp_process_state_queue_.empty())
+      << "The tmp_process_state_queue_ should be empty before AdvanceToken.";
+  tmp_states_visited_in_queue_.Clear();
+  tmp_states_to_be_added_.clear();
+  tmp_accept_stop_token_ = false;
+  const auto& latest_states = scanable_state_history_[scanable_state_history_.size() - 1];
+  for (const auto& state : latest_states) {
+    ScanAtomicToken(state, token_id);
+  }
+  if (tmp_process_state_queue_.empty() && tmp_states_to_be_added_.empty()) {
+    return false;
+  }
+  rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
+  while (!tmp_process_state_queue_.empty()) {
+    const auto state = std::move(tmp_process_state_queue_.front());
+    tmp_process_state_queue_.pop();
+    auto [scanable, completable] = Predict(state, debug_print);
+    if (completable) {
+      Complete(state, debug_print);
+    }
+    if (scanable) {
+      tmp_states_to_be_added_.push_back(state);
+    }
+  }
+  is_completed_.push_back(tmp_accept_stop_token_);
+  scanable_state_history_.PushBack(tmp_states_to_be_added_);
+  return true;
 }
 
 bool RepeatDetector::IsVisited(const ParserState& state) const {

--- a/cpp/earley_parser.h
+++ b/cpp/earley_parser.h
@@ -378,6 +378,19 @@ class EarleyParser {
   void AdvanceFsm(const ParserState& state, const uint8_t ch);
 
   /*!
+   * \brief Scan a token set edge: check if token_id matches any kTokenSet edge from state.
+   */
+  void ScanAtomicToken(const ParserState& state, int32_t token_id);
+
+  /*!
+   * \brief Advance the parser by accepting a whole token via kTokenSet edges.
+   * \param token_id The token ID to accept.
+   * \param debug_print Whether to print debug info.
+   * \return True if any state advanced, false otherwise.
+   */
+  bool AdvanceToken(int32_t token_id, bool debug_print = false);
+
+  /*!
    * \brief Enqueue the state into the queue.
    * \param state The state to be enqueued.
    * \details The state is enqueued if it is not visited in the queue.

--- a/cpp/fsm.cc
+++ b/cpp/fsm.cc
@@ -78,6 +78,12 @@ class FSMImplBase {
 
   RepeatEdgeRef GetRepeatEdgeInfo(int16_t idx) const { return {edge_aux_data_.data() + idx}; }
 
+  TokenSetEdgeRef GetTokenSetEdgeInfo(int16_t idx) const { return {edge_aux_data_.data() + idx}; }
+
+  TokenExcludeEdgeRef GetTokenExcludeEdgeInfo(int16_t idx) const {
+    return {edge_aux_data_.data() + idx};
+  }
+
  protected:
   ContainerType edges_;
   std::vector<int32_t> edge_aux_data_;
@@ -111,6 +117,22 @@ std::string FSMImplBase<ContainerType>::EdgesToString(std::optional<std::vector<
         result += "Repeat(rule=" + std::to_string(info.RuleId()) +
                   ", min=" + std::to_string(info.Lower()) +
                   ", max=" + std::to_string(info.Upper()) + ")->" + std::to_string(edge.target);
+      } else if (edge.min == FSMEdge::EdgeType::kTokenSet) {
+        auto info = GetTokenSetEdgeInfo(edge.max);
+        result += "Token(";
+        for (int32_t k = 0; k < info.Count(); ++k) {
+          if (k > 0) result += ", ";
+          result += std::to_string(info.TokenIds()[k]);
+        }
+        result += ")->" + std::to_string(edge.target);
+      } else if (edge.min == FSMEdge::EdgeType::kTokenExclude) {
+        auto info = GetTokenExcludeEdgeInfo(edge.max);
+        result += "TokenExclude(";
+        for (int32_t k = 0; k < info.Count(); ++k) {
+          if (k > 0) result += ", ";
+          result += std::to_string(info.TokenIds()[k]);
+        }
+        result += ")->" + std::to_string(edge.target);
       }
       if (j < static_cast<int>(edges.size()) - 1) {
         result += ", ";
@@ -241,6 +263,28 @@ class FSM::Impl : public FSMImplBase<std::vector<std::vector<FSMEdge>>> {
     edge_aux_data_.emplace_back(lower);
     edge_aux_data_.emplace_back(upper);
     AddEdge(from, to, FSMEdge::EdgeType::kRepeatRef, aux_index);
+  }
+
+  void AddTokenSetEdge(int from, int to, const std::vector<int32_t>& token_ids) {
+    XGRAMMAR_DCHECK(!token_ids.empty()) << "Token set must not be empty";
+    int16_t aux_index = static_cast<int16_t>(edge_aux_data_.size());
+    XGRAMMAR_CHECK(aux_index >= 0) << "edge_aux_data_ overflow: too many auxiliary data entries";
+    edge_aux_data_.push_back(static_cast<int32_t>(token_ids.size()));
+    for (int32_t id : token_ids) {
+      edge_aux_data_.push_back(id);
+    }
+    edges_[from].push_back(FSMEdge(FSMEdge::EdgeType::kTokenSet, aux_index, to));
+  }
+
+  void AddTokenExcludeEdge(int state, const std::vector<int32_t>& token_ids) {
+    XGRAMMAR_DCHECK(!token_ids.empty()) << "Token exclude set must not be empty";
+    int16_t aux_index = static_cast<int16_t>(edge_aux_data_.size());
+    XGRAMMAR_CHECK(aux_index >= 0) << "edge_aux_data_ overflow: too many auxiliary data entries";
+    edge_aux_data_.push_back(static_cast<int32_t>(token_ids.size()));
+    for (int32_t id : token_ids) {
+      edge_aux_data_.push_back(id);
+    }
+    edges_[state].push_back(FSMEdge(FSMEdge::EdgeType::kTokenExclude, aux_index, state));
   }
 
   void AddFSM(const FSM& fsm, std::vector<int>* state_mapping);
@@ -444,11 +488,27 @@ void FSM::AddRepeatEdge(int from, int to, int32_t rule_id, int32_t lower, int32_
   pimpl_->AddRepeatEdge(from, to, rule_id, lower, upper);
 }
 
+void FSM::AddTokenSetEdge(int from, int to, const std::vector<int32_t>& token_ids) {
+  pimpl_->AddTokenSetEdge(from, to, token_ids);
+}
+
+void FSM::AddTokenExcludeEdge(int state, const std::vector<int32_t>& token_ids) {
+  pimpl_->AddTokenExcludeEdge(state, token_ids);
+}
+
 const std::vector<int32_t>& FSM::GetEdgeAuxData() const { return pimpl_->GetEdgeAuxData(); }
 
 void FSM::SetEdgeAuxData(std::vector<int32_t> data) { pimpl_->SetEdgeAuxData(std::move(data)); }
 
 RepeatEdgeRef FSM::GetRepeatEdgeInfo(int16_t idx) const { return pimpl_->GetRepeatEdgeInfo(idx); }
+
+TokenSetEdgeRef FSM::GetTokenSetEdgeInfo(int16_t idx) const {
+  return pimpl_->GetTokenSetEdgeInfo(idx);
+}
+
+TokenExcludeEdgeRef FSM::GetTokenExcludeEdgeInfo(int16_t idx) const {
+  return pimpl_->GetTokenExcludeEdgeInfo(idx);
+}
 
 void FSM::AddFSM(const FSM& fsm, std::vector<int>* state_mapping) {
   pimpl_->AddFSM(fsm, state_mapping);
@@ -726,6 +786,14 @@ void CompactFSM::SetEdgeAuxData(std::vector<int32_t> data) {
 
 RepeatEdgeRef CompactFSM::GetRepeatEdgeInfo(int16_t idx) const {
   return pimpl_->GetRepeatEdgeInfo(idx);
+}
+
+TokenSetEdgeRef CompactFSM::GetTokenSetEdgeInfo(int16_t idx) const {
+  return pimpl_->GetTokenSetEdgeInfo(idx);
+}
+
+TokenExcludeEdgeRef CompactFSM::GetTokenExcludeEdgeInfo(int16_t idx) const {
+  return pimpl_->GetTokenExcludeEdgeInfo(idx);
 }
 
 picojson::value SerializeJSONValue(const CompactFSM& value) {
@@ -1130,12 +1198,23 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
   UnionFindSet<int> union_find_set;
   std::vector<int> in_degree(NumStates(), 0);
   std::vector<std::pair<int32_t, int32_t>> epsilon_edges;
+
+  std::vector<bool> has_token_exclude(NumStates(), false);
+  for (int i = 0; i < NumStates(); i++) {
+    for (const auto& edge : fsm_->GetEdges(i)) {
+      if (edge.IsTokenExclude()) {
+        has_token_exclude[i] = true;
+        break;
+      }
+    }
+  }
+
   for (int i = 0; i < NumStates(); i++) {
     const auto& edges = fsm_->GetEdges(i);
     for (const auto& edge : edges) {
       in_degree[edge.target]++;
       if (edge.IsEpsilon()) {
-        if (edges.size() == 1) {
+        if (edges.size() == 1 && !has_token_exclude[i] && !has_token_exclude[edge.target]) {
           // a -- epsilon --> b, and a doesn't have other outward edges.
           union_find_set.Add(i);
           union_find_set.Add(edge.target);
@@ -1167,7 +1246,8 @@ FSMWithStartEnd FSMWithStartEnd::SimplifyEpsilon(int max_num_states) const {
   for (const auto& [from_raw, to_raw] : epsilon_edges) {
     const int& from = equiv_node[from_raw];
     const int& to = equiv_node[to_raw];
-    if (in_degree[to] == 1 && equiv_node[GetStart()] != to) {
+    if (in_degree[to] == 1 && equiv_node[GetStart()] != to && !has_token_exclude[from_raw] &&
+        !has_token_exclude[to_raw]) {
       union_find_set.Add(from);
       union_find_set.Add(to);
       union_find_set.Union(from, to);
@@ -1492,6 +1572,8 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
   while (now_process < static_cast<int>(closures.size())) {
     rules.clear();
     repeat_aux_indices.clear();
+    std::unordered_set<int16_t> token_set_aux_indices;
+    std::set<int32_t> merged_token_exclude_ids;
     std::set<int> interval_ends;
     std::bitset<256> allowed_characters;
     dfa.AddState();
@@ -1513,6 +1595,11 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
           rules.insert(edge.GetRefRuleId());
         } else if (edge.IsRepeatRef()) {
           repeat_aux_indices.insert(edge.GetAuxIndex());
+        } else if (edge.IsTokenSet()) {
+          token_set_aux_indices.insert(edge.GetAuxIndex());
+        } else if (edge.IsTokenExclude()) {
+          auto info = fsm_.GetTokenExcludeEdgeInfo(edge.GetAuxIndex());
+          merged_token_exclude_ids.insert(info.TokenIds(), info.TokenIds() + info.Count());
         }
       }
     }
@@ -1628,6 +1715,43 @@ Result<FSMWithStartEnd> FSMWithStartEnd::ToDFA(int max_num_states) const {
         closures.push_back(next_closure);
       }
     }
+
+    for (auto aux_idx : token_set_aux_indices) {
+      std::unordered_set<int> next_closure;
+      for (const auto& state : closures[now_process]) {
+        const auto& edges = fsm_.GetEdges(state);
+        for (const auto& edge : edges) {
+          if (edge.IsTokenSet() && edge.GetAuxIndex() == aux_idx) {
+            if (next_closure.find(edge.target) == next_closure.end()) {
+              std::unordered_set<int> epsilon_closure;
+              epsilon_closure.insert(edge.target);
+              fsm_.GetEpsilonClosure(&epsilon_closure);
+              next_closure.insert(epsilon_closure.begin(), epsilon_closure.end());
+            }
+          }
+        }
+      }
+      bool flag = false;
+      for (int j = 0; j < static_cast<int>(closures.size()); j++) {
+        if (closures[j] == next_closure) {
+          dfa.GetFsm().AddEdge(now_process, j, FSMEdge::EdgeType::kTokenSet, aux_idx);
+          flag = true;
+          break;
+        }
+      }
+      if (!flag) {
+        dfa.GetFsm().AddEdge(now_process, closures.size(), FSMEdge::EdgeType::kTokenSet, aux_idx);
+        closures.push_back(next_closure);
+      }
+    }
+
+    if (!merged_token_exclude_ids.empty()) {
+      std::vector<int32_t> exclude_vec(
+          merged_token_exclude_ids.begin(), merged_token_exclude_ids.end()
+      );
+      dfa.GetFsm().AddTokenExcludeEdge(now_process, exclude_vec);
+    }
+
     now_process++;
   }
   dfa.GetFsm().SetEdgeAuxData(std::vector<int32_t>(fsm_.GetEdgeAuxData()));

--- a/cpp/fsm.h
+++ b/cpp/fsm.h
@@ -41,6 +41,8 @@ struct alignas(8) FSMEdge {
     kRuleRef = -2,
     kEOS = -3,
     kRepeatRef = -4,
+    kTokenSet = -5,
+    kTokenExclude = -6,
   };
 
   inline static constexpr int kMaxChar = 255;
@@ -112,6 +114,10 @@ struct alignas(8) FSMEdge {
    */
   bool IsRepeatRef() const { return min == EdgeType::kRepeatRef; }
 
+  bool IsTokenSet() const { return min == EdgeType::kTokenSet; }
+
+  bool IsTokenExclude() const { return min == EdgeType::kTokenExclude; }
+
   /*!
    * \brief Get the rule id of the edge.
    * \return The rule id of the edge. -1 if the edge is not a rule reference.
@@ -122,10 +128,12 @@ struct alignas(8) FSMEdge {
    * \brief Get the auxiliary data index for repeat reference edges.
    * \return The index into the owning FSM's edge_aux_data. -1 if not a repeat reference.
    */
-  int16_t GetAuxIndex() const { return IsRepeatRef() ? max : -1; }
+  int16_t GetAuxIndex() const {
+    return (IsRepeatRef() || IsTokenSet() || IsTokenExclude()) ? max : -1;
+  }
 
-  /*! \brief Check if the edge uses auxiliary data (currently only kRepeatRef). */
-  bool IsAuxEdge() const { return IsRepeatRef(); }
+  /*! \brief Check if the edge uses auxiliary data. */
+  bool IsAuxEdge() const { return IsRepeatRef() || IsTokenSet() || IsTokenExclude(); }
 
   friend struct member_trait<FSMEdge>;
 };
@@ -136,6 +144,26 @@ struct RepeatEdgeRef {
   int16_t RuleId() const { return static_cast<int16_t>(data[0]); }
   int32_t Lower() const { return data[1]; }
   int32_t Upper() const { return data[2]; }
+};
+
+/*! \brief View into edge_aux_data for a token set edge (layout: [count, token_id_0, ...]). */
+struct TokenSetEdgeRef {
+  const int32_t* data;
+  int32_t Count() const { return data[0]; }
+  const int32_t* TokenIds() const { return data + 1; }
+  bool Contains(int32_t token_id) const {
+    return std::binary_search(TokenIds(), TokenIds() + Count(), token_id);
+  }
+};
+
+/*! \brief View into edge_aux_data for a token exclude edge (layout: [count, token_id_0, ...]). */
+struct TokenExcludeEdgeRef {
+  const int32_t* data;
+  int32_t Count() const { return data[0]; }
+  const int32_t* TokenIds() const { return data + 1; }
+  bool Contains(int32_t token_id) const {
+    return std::binary_search(TokenIds(), TokenIds() + Count(), token_id);
+  }
 };
 
 /*!
@@ -325,6 +353,10 @@ class FSM {
    */
   void AddRepeatEdge(int from, int to, int32_t rule_id, int32_t lower, int32_t upper);
 
+  void AddTokenSetEdge(int from, int to, const std::vector<int32_t>& token_ids);
+
+  void AddTokenExcludeEdge(int state, const std::vector<int32_t>& token_ids);
+
   /*! \brief Get the edge auxiliary data. */
   const std::vector<int32_t>& GetEdgeAuxData() const;
 
@@ -333,6 +365,12 @@ class FSM {
 
   /*! \brief Get repeat edge info by aux index. */
   RepeatEdgeRef GetRepeatEdgeInfo(int16_t idx) const;
+
+  /*! \brief Get token set edge info by aux index. */
+  TokenSetEdgeRef GetTokenSetEdgeInfo(int16_t idx) const;
+
+  /*! \brief Get token exclude edge info by aux index. */
+  TokenExcludeEdgeRef GetTokenExcludeEdgeInfo(int16_t idx) const;
 
   /*!
    * \brief Add a whole FSM to the current FSM.
@@ -496,6 +534,12 @@ class CompactFSM {
   /*! \brief Get repeat edge info by aux index. */
   RepeatEdgeRef GetRepeatEdgeInfo(int16_t idx) const;
 
+  /*! \brief Get token set edge info by aux index. */
+  TokenSetEdgeRef GetTokenSetEdgeInfo(int16_t idx) const;
+
+  /*! \brief Get token exclude edge info by aux index. */
+  TokenExcludeEdgeRef GetTokenExcludeEdgeInfo(int16_t idx) const;
+
   /****************** CompactFSM Construction Methods ******************/
 
   /*!
@@ -562,7 +606,7 @@ class FSMWithStartEndBase {
    */
   bool IsScanableState(int state) const {
     for (const auto& edge : fsm_.GetEdges(state)) {
-      if (edge.IsCharRange()) {
+      if (edge.IsCharRange() || edge.IsTokenSet()) {
         return true;
       }
     }

--- a/cpp/grammar_compiler.cc
+++ b/cpp/grammar_compiler.cc
@@ -740,7 +740,18 @@ AdaptiveTokenMask GrammarMatcherForTokenMaskCache::GetAdaptiveTokenMask(bool is_
   std::bitset<256> first_character_mask;
   GetFirstCharacterMask(first_character_mask);
 
-  bool rejected_filled = GetTokenMaskWithFirstCharacterCheck(first_character_mask, is_root_rule);
+  bool rejected_filled;
+  if (first_character_mask.none()) {
+    // Token-set-only state: no char edges, so all tokens are rejected from char-based perspective.
+    // kTokenSet contributions are handled in FillNextTokenBitmask at runtime.
+    const auto& sorted_decoded_vocab = tokenizer_info_.GetSortedDecodedVocab();
+    for (int i = 0; i < static_cast<int>(sorted_decoded_vocab.size()); ++i) {
+      tmp_rejected_indices_.push_back(i);
+    }
+    rejected_filled = true;
+  } else {
+    rejected_filled = GetTokenMaskWithFirstCharacterCheck(first_character_mask, is_root_rule);
+  }
   if (rejected_filled) {
     auto return_value = AdaptiveTokenMask(
         tokenizer_info_.GetVocabSize(),

--- a/cpp/grammar_functor.cc
+++ b/cpp/grammar_functor.cc
@@ -288,6 +288,7 @@ class StructureNormalizerImpl : public GrammarMutator {
       case GrammarExprType::kCharacterClassStar:
       case GrammarExprType::kRuleRef:
       case GrammarExprType::kRepeat:
+      case GrammarExprType::kTokenSet:
         return builder_->AddSequence({builder_->AddGrammarExpr(assertion_expr)});
       default:
         XGRAMMAR_LOG(FATAL) << "Unexpected lookahead assertion type: "
@@ -310,6 +311,7 @@ class StructureNormalizerImpl : public GrammarMutator {
       case GrammarExprType::kCharacterClassStar:
       case GrammarExprType::kRuleRef:
       case GrammarExprType::kRepeat:
+      case GrammarExprType::kTokenSet:
         return builder_->AddChoices({builder_->AddSequence({builder_->AddGrammarExpr(grammar_expr)})
         });
       case GrammarExprType::kTagDispatch:
@@ -344,6 +346,7 @@ class StructureNormalizerImpl : public GrammarMutator {
         case GrammarExprType::kCharacterClassStar:
         case GrammarExprType::kRuleRef:
         case GrammarExprType::kRepeat:
+        case GrammarExprType::kTokenSet:
           VisitElementInChoices(choice_expr, &new_choice_ids);
           break;
         case GrammarExprType::kTagDispatch: {
@@ -423,6 +426,7 @@ class StructureNormalizerImpl : public GrammarMutator {
         case GrammarExprType::kCharacterClassStar:
         case GrammarExprType::kRuleRef:
         case GrammarExprType::kRepeat:
+        case GrammarExprType::kTokenSet:
           VisitElementInSequence(element_expr, &new_sequence_ids);
           break;
         case GrammarExprType::kTagDispatch: {
@@ -1054,6 +1058,7 @@ class GrammarFSMBuilderImpl {
   static FSMWithStartEnd CharacterClass(const GrammarExpr& expr);
   static FSMWithStartEnd ByteString(const GrammarExpr& expr);
   static FSMWithStartEnd Repeat(const GrammarExpr& expr);
+  static FSMWithStartEnd TokenSet(const GrammarExpr& expr);
   static std::optional<FSMWithStartEnd> Sequence(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> Choices(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> TagDispatch(const Grammar::Impl::TagDispatch& tag_dispatch);
@@ -1379,6 +1384,20 @@ FSMWithStartEnd GrammarFSMBuilderImpl::Repeat(const GrammarExpr& expr) {
   return repeat_fsm;
 }
 
+FSMWithStartEnd GrammarFSMBuilderImpl::TokenSet(const GrammarExpr& expr) {
+  std::vector<int32_t> token_ids;
+  for (int i = 0; i < expr.data_len; ++i) {
+    token_ids.push_back(expr[i]);
+  }
+  FSMWithStartEnd result_fsm;
+  result_fsm.AddState();
+  result_fsm.AddState();
+  result_fsm.SetStartState(0);
+  result_fsm.AddEndState(1);
+  result_fsm.GetFsm().AddTokenSetEdge(0, 1, token_ids);
+  return result_fsm;
+}
+
 std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Sequence(
     const GrammarExpr& expr, const Grammar& grammar
 ) {
@@ -1403,6 +1422,10 @@ std::optional<FSMWithStartEnd> GrammarFSMBuilderImpl::Sequence(
       }
       case (ExprType::kRepeat): {
         fsm_lists.push_back(Repeat(sequence_expr));
+        break;
+      }
+      case (ExprType::kTokenSet): {
+        fsm_lists.push_back(TokenSet(sequence_expr));
         break;
       }
       default: {
@@ -2242,6 +2265,12 @@ std::optional<uint64_t> GrammarFSMHasherImpl::HashSequence(
       case (GrammarExprType::kTagDispatch): {
         return std::nullopt;
       }
+      case (GrammarExprType::kTokenSet): {
+        for (const auto& element : expr) {
+          hash_result = HashCombine(hash_result, element);
+        }
+        break;
+      }
     }
   }
   return hash_result;
@@ -2461,6 +2490,10 @@ FSMWithStartEnd GrammarFSMBuilder::CharacterClass(const GrammarExpr& expr) {
 
 FSMWithStartEnd GrammarFSMBuilder::ByteString(const GrammarExpr& expr) {
   return GrammarFSMBuilderImpl::ByteString(expr);
+}
+
+FSMWithStartEnd GrammarFSMBuilder::TokenSet(const GrammarExpr& expr) {
+  return GrammarFSMBuilderImpl::TokenSet(expr);
 }
 
 std::optional<FSMWithStartEnd> GrammarFSMBuilder::Sequence(

--- a/cpp/grammar_functor.h
+++ b/cpp/grammar_functor.h
@@ -137,6 +137,8 @@ class GrammarFunctor {
         return VisitTagDispatch(grammar_expr);
       case GrammarExprType::kRepeat:
         return VisitRepeat(grammar_expr);
+      case GrammarExprType::kTokenSet:
+        return VisitTokenSet(grammar_expr);
       default:
         XGRAMMAR_LOG(FATAL) << "Unexpected sequence type: " << static_cast<int>(grammar_expr.type);
         XGRAMMAR_UNREACHABLE();
@@ -220,6 +222,9 @@ class GrammarFunctor {
 
   /*! \brief Visit a repeat GrammarExpr. */
   virtual T VisitRepeat(const GrammarExpr& grammar_expr) { return VisitElement(grammar_expr); }
+
+  /*! \brief Visit a token set GrammarExpr. */
+  virtual T VisitTokenSet(const GrammarExpr& grammar_expr) { return VisitElement(grammar_expr); }
 
   /*! \brief The grammar to visit or mutate. */
   Grammar base_grammar_{NullObj{}};
@@ -349,6 +354,7 @@ class GrammarFSMBuilder {
   static FSMWithStartEnd RuleRef(const GrammarExpr& expr);
   static FSMWithStartEnd CharacterClass(const GrammarExpr& expr);
   static FSMWithStartEnd ByteString(const GrammarExpr& expr);
+  static FSMWithStartEnd TokenSet(const GrammarExpr& expr);
   static std::optional<FSMWithStartEnd> Sequence(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> Choices(const GrammarExpr& expr, const Grammar& grammar);
   static std::optional<FSMWithStartEnd> TagDispatch(const Grammar::Impl::TagDispatch& tag_dispatch);

--- a/cpp/grammar_impl.h
+++ b/cpp/grammar_impl.h
@@ -127,6 +127,8 @@ class Grammar::Impl {
     kTagDispatch,
     // data format: [rule_id, min_repeat_count, max_repeat_count]
     kRepeat,
+    // data format: [token_id_0, token_id_1, ...]
+    kTokenSet,
   };
 
   /*! \brief The object representing a grammar expr. */

--- a/cpp/grammar_matcher.cc
+++ b/cpp/grammar_matcher.cc
@@ -531,25 +531,64 @@ bool GrammarMatcher::Impl::AcceptToken(int32_t token_id, bool debug_print) {
   }
 
   const auto& token = tokenizer_info_.GetDecodedVocab()[token_id];
+
+  // Phase 1: Try token path (AdvanceToken for kTokenSet edges)
+  std::vector<ParserState> token_path_states;
+  bool token_path_completed = false;
+  bool token_path_success = AdvanceToken(token_id, debug_print);
+  if (token_path_success) {
+    token_path_states = GetLatestScanableStates();
+    token_path_completed = is_completed_.back();
+    PopLastStates(1);
+  }
+
+  // Phase 2: Try byte-by-byte path
   int pos = 0;
+  bool byte_path_success = true;
   for (auto char_value : token) {
     if (!Advance(char_value, debug_print)) {
-      if (debug_print) {
-        XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<" << EscapeString(token)
-                           << "> rejected at position " << pos << ", char "
-                           << EscapeString(char_value);
-      }
-      PopLastStates(pos);
-      return false;
+      byte_path_success = false;
+      break;
     }
     ++pos;
   }
-  token_length_history.push_back(token.size());
+
+  // Phase 3: Combine results
+  if (!byte_path_success && !token_path_success) {
+    if (debug_print) {
+      XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<" << EscapeString(token)
+                         << "> rejected at position " << pos;
+    }
+    PopLastStates(pos);
+    return false;
+  }
+
+  if (!byte_path_success) {
+    PopLastStates(pos);
+    AdvanceToken(token_id, debug_print);
+    token_length_history.push_back(1);
+  } else {
+    if (!token_path_states.empty()) {
+      std::vector<ParserState> merged;
+      for (const auto& s : GetLatestScanableStates()) {
+        merged.push_back(s);
+      }
+      for (const auto& s : token_path_states) {
+        if (std::find(merged.begin(), merged.end(), s) == merged.end()) {
+          merged.push_back(s);
+        }
+      }
+      bool prev_completed = is_completed_.back();
+      PopLastStates(1);
+      scanable_state_history_.PushBack(merged);
+      rule_id_to_completable_states_.PushBack(std::vector<std::pair<int32_t, ParserState>>());
+      is_completed_.push_back(prev_completed || token_path_completed);
+    }
+    token_length_history.push_back(token.size());
+  }
 
   if (debug_print) {
-    XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<"
-                       << EscapeString(tokenizer_info_.GetDecodedVocab()[token_id])
-                       << "> accepted.";
+    XGRAMMAR_LOG(INFO) << "Token #" << token_id << "<" << EscapeString(token) << "> accepted.";
   }
   return true;
 }
@@ -762,6 +801,24 @@ bool GrammarMatcher::Impl::FillNextTokenBitmask(
       //     adaptive_token_mask.rejected_indices + rejected_indices_delta)
       IntsetUnion(&tmp_rejected_indices_delta_, adaptive_token_mask.rejected_indices);
       IntsetIntersection(&tmp_rejected_indices_, tmp_rejected_indices_delta_);
+    }
+  }
+
+  // Handle kTokenSet edges: add token IDs accepted by kTokenSet edges to the accepted bitset
+  for (const auto& state : latest_states) {
+    if (state.rule_id == -1) continue;
+    if (!grammar_->per_rule_fsms[state.rule_id].has_value()) continue;
+    const auto& fsm = grammar_->per_rule_fsms[state.rule_id].value();
+    for (const auto& edge : fsm.GetFsm().GetEdges(state.element_id)) {
+      if (edge.IsTokenSet()) {
+        auto info = fsm.GetFsm().GetTokenSetEdgeInfo(edge.GetAuxIndex());
+        for (int32_t i = 0; i < info.Count(); ++i) {
+          int32_t tid = info.TokenIds()[i];
+          if (tid >= 0 && tid < tokenizer_info_.GetVocabSize()) {
+            tmp_accepted_bitset_.Set(tid, true);
+          }
+        }
+      }
     }
   }
 

--- a/cpp/grammar_parser.cc
+++ b/cpp/grammar_parser.cc
@@ -7,6 +7,7 @@
 
 #include <picojson.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -490,6 +491,7 @@ class EBNFParser {
   MacroIR::NodePtr ParseMacroValue();
 
   int32_t ParseTagDispatch();
+  int32_t ParseTokenSet();
 
   // Helper functions
 
@@ -540,6 +542,7 @@ class EBNFParser {
 const std::unordered_map<std::string, std::function<int32_t(EBNFParser*)>>
     EBNFParser::kMacroFunctions = {
         {"TagDispatch", [](EBNFParser* parser) { return parser->ParseTagDispatch(); }},
+        {"Token", [](EBNFParser* parser) { return parser->ParseTokenSet(); }},
 };
 
 const EBNFParser::Token& EBNFParser::Peek(int delta) const { return *(current_token_ + delta); }
@@ -1152,6 +1155,37 @@ int32_t EBNFParser::ParseTagDispatch() {
   }
 
   return builder_.AddTagDispatch(tag_dispatch);
+}
+
+int32_t EBNFParser::ParseTokenSet() {
+  Consume();  // Consume Token identifier
+  auto start = current_token_;
+  auto args = ParseMacroArguments();
+  auto delta_element = start - current_token_;
+
+  if (!args.named_arguments.empty()) {
+    ReportParseError("Token() does not accept named arguments", delta_element);
+  }
+
+  if (args.arguments.empty()) {
+    ReportParseError("Token() requires at least one integer argument", delta_element);
+  }
+
+  std::vector<int32_t> token_ids;
+  for (const auto& arg : args.arguments) {
+    auto int_node = std::get_if<MacroIR::IntegerNode>(arg.get());
+    if (int_node == nullptr || int_node->value < 0) {
+      ReportParseError("Token() arguments must be non-negative integers", delta_element);
+    }
+    token_ids.push_back(static_cast<int32_t>(int_node->value));
+  }
+
+  std::sort(token_ids.begin(), token_ids.end());
+  token_ids.erase(std::unique(token_ids.begin(), token_ids.end()), token_ids.end());
+
+  return builder_.AddGrammarExpr(
+      {GrammarExprType::kTokenSet, token_ids.data(), static_cast<int32_t>(token_ids.size())}
+  );
 }
 
 int32_t EBNFParser::ParseLookaheadAssertion() {

--- a/cpp/grammar_printer.cc
+++ b/cpp/grammar_printer.cc
@@ -44,6 +44,8 @@ std::string GrammarPrinter::PrintGrammarExpr(const GrammarExpr& grammar_expr) {
       return PrintTagDispatch(grammar_expr);
     case GrammarExprType::kRepeat:
       return PrintRepeat(grammar_expr);
+    case GrammarExprType::kTokenSet:
+      return PrintTokenSet(grammar_expr);
     default:
       XGRAMMAR_LOG(FATAL) << "Unexpected GrammarExpr type: " << static_cast<int>(grammar_expr.type);
       XGRAMMAR_UNREACHABLE();
@@ -164,6 +166,16 @@ std::string GrammarPrinter::PrintRepeat(const GrammarExpr& grammar_expr) {
   result += ", ";
   result += std::to_string(upper_bound);
   result += "}";
+  return result;
+}
+
+std::string GrammarPrinter::PrintTokenSet(const GrammarExpr& grammar_expr) {
+  std::string result = "Token(";
+  for (int i = 0; i < grammar_expr.data_len; ++i) {
+    if (i > 0) result += ", ";
+    result += std::to_string(grammar_expr[i]);
+  }
+  result += ")";
   return result;
 }
 

--- a/cpp/grammar_printer.h
+++ b/cpp/grammar_printer.h
@@ -62,6 +62,8 @@ class GrammarPrinter {
   std::string PrintTagDispatch(const GrammarExpr& grammar_expr);
   /*! \brief Print a GrammarExpr for repeat. */
   std::string PrintRepeat(const GrammarExpr& grammar_expr);
+  /*! \brief Print a GrammarExpr for token set. */
+  std::string PrintTokenSet(const GrammarExpr& grammar_expr);
   /*! \brief Print a string. */
   std::string PrintString(const std::string& str);
   /*! \brief Print a boolean. */

--- a/tests/python/test_token_edge.py
+++ b/tests/python/test_token_edge.py
@@ -1,0 +1,189 @@
+"""Tests for Token() edge support in grammar parsing, matching, and bitmask generation."""
+
+import pytest
+import torch
+
+import xgrammar as xgr
+from xgrammar.testing import (
+    _ebnf_to_grammar_no_normalization,
+    _get_masked_tokens_from_bitmask,
+    _get_matcher_from_grammar_and_tokenizer_info,
+    _is_grammar_accept_string,
+)
+
+# --- Parser / Printer roundtrip tests ---
+
+
+def test_parse_token_basic():
+    before = "root ::= Token(1, 2, 3)\n"
+    expected = "root ::= ((Token(1, 2, 3)))\n"
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+def test_parse_token_single():
+    before = "root ::= Token(42)\n"
+    expected = "root ::= ((Token(42)))\n"
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+def test_parse_token_sorted_deduped():
+    before = "root ::= Token(3, 1, 2, 1, 3)\n"
+    expected = "root ::= ((Token(1, 2, 3)))\n"
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+def test_parse_token_in_sequence():
+    before = 'root ::= Token(1, 2) "hello"\n'
+    expected = 'root ::= ((Token(1, 2) "hello"))\n'
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+def test_parse_token_in_alternation():
+    before = 'root ::= Token(1) | "hello"\n'
+    expected = 'root ::= ((Token(1)) | ("hello"))\n'
+    grammar = _ebnf_to_grammar_no_normalization(before)
+    assert str(grammar) == expected
+
+
+# --- Matcher accept_token tests ---
+
+
+STOP_TOKEN_ID = 1  # "</s>" in our test vocab
+
+
+def _make_matcher(vocab, grammar_str):
+    """Create a matcher with a custom vocab and grammar."""
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf(grammar_str)
+    return _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+
+def test_accept_token_basic():
+    """Token(2, 4) should accept token IDs 2 and 4 but reject others."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc", "dd"]
+    #         0      1       2     3     4     5
+    matcher = _make_matcher(vocab, "root ::= Token(2, 4)\n")
+
+    assert matcher.accept_token(2)
+    assert matcher.accept_token(STOP_TOKEN_ID)
+    assert matcher.is_terminated()
+
+
+def test_accept_token_reject():
+    """Tokens not in the Token() set should be rejected."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc", "dd"]
+    matcher = _make_matcher(vocab, "root ::= Token(2, 4)\n")
+
+    assert not matcher.accept_token(3)
+    assert not matcher.accept_token(5)
+    assert matcher.accept_token(4)
+    assert matcher.accept_token(STOP_TOKEN_ID)
+    assert matcher.is_terminated()
+
+
+def test_token_then_string():
+    """Token followed by string literal: Token(2) "bb" ."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc"]
+    matcher = _make_matcher(vocab, 'root ::= Token(2) "bb"\n')
+
+    assert matcher.accept_token(2)  # Token(2) = "aa"
+    assert matcher.accept_token(3)  # "bb"
+    assert matcher.accept_token(STOP_TOKEN_ID)
+    assert matcher.is_terminated()
+
+
+def test_token_or_string():
+    """Alternation: Token(2) | "bb" ."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc"]
+
+    # Accept via token path
+    matcher = _make_matcher(vocab, 'root ::= Token(2) | "bb"\n')
+    assert matcher.accept_token(2)
+    assert matcher.accept_token(STOP_TOKEN_ID)
+    assert matcher.is_terminated()
+
+    # Accept via string path
+    matcher2 = _make_matcher(vocab, 'root ::= Token(2) | "bb"\n')
+    assert matcher2.accept_token(3)  # "bb"
+    assert matcher2.accept_token(STOP_TOKEN_ID)
+    assert matcher2.is_terminated()
+
+
+# --- Bitmask tests ---
+
+
+def test_bitmask_token_only():
+    """FillNextTokenBitmask should allow only tokens in Token() set (and stop token)."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc", "dd"]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf("root ::= Token(2, 4)\n")
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected = _get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size)
+
+    assert 2 not in rejected
+    assert 4 not in rejected
+    assert 0 in rejected  # <s>
+    assert 3 in rejected  # "bb"
+    assert 5 in rejected  # "dd"
+
+
+def test_bitmask_token_and_string():
+    """Bitmask for Token(2) | "bb" should allow token 2 and token whose text is "bb"."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc"]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf('root ::= Token(2) | "bb"\n')
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected = _get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size)
+
+    assert 2 not in rejected  # Token(2) via kTokenSet
+    assert 3 not in rejected  # "bb" via char path
+
+
+def test_bitmask_after_token():
+    """After accepting a Token, the bitmask should reflect the next expected tokens."""
+    vocab = ["<s>", "</s>", "aa", "bb", "cc"]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf('root ::= Token(2) "bb"\n')
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+    # First: only token 2 should be allowed
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected = _get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size)
+    assert 2 not in rejected
+
+    # Accept token 2
+    assert matcher.accept_token(2)
+
+    # Second: "bb" tokens should be allowed
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected2 = _get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size)
+    assert 3 not in rejected2  # "bb" token
+
+
+def test_token_multiple_choices():
+    """Token set with multiple IDs in alternation with other rules."""
+    vocab = ["<s>", "</s>", "x", "y", "z", "w"]
+    tokenizer_info = xgr.TokenizerInfo(vocab)
+    grammar = xgr.Grammar.from_ebnf('root ::= Token(2, 3, 4) | "w"\n')
+    matcher = _get_matcher_from_grammar_and_tokenizer_info(grammar, tokenizer_info)
+
+    token_bitmask = xgr.allocate_token_bitmask(1, tokenizer_info.vocab_size)
+    matcher.fill_next_token_bitmask(token_bitmask)
+    rejected = _get_masked_tokens_from_bitmask(token_bitmask, tokenizer_info.vocab_size)
+
+    assert 2 not in rejected  # "x" via kTokenSet
+    assert 3 not in rejected  # "y" via kTokenSet
+    assert 4 not in rejected  # "z" via kTokenSet
+    assert 5 not in rejected  # "w" via char path
+    assert 0 in rejected  # "<s>" rejected


### PR DESCRIPTION
## Summary

- Add token-level edge types (`kTokenSet`, `kTokenExclude`) to the FSM layer, enabling atomic token matching alongside character-based matching
- Introduce `Token(id1, id2, ...)` grammar macro for EBNF, with parser, printer, and FSM builder support
- Implement dual-path `AcceptToken` in the matcher (token path via `AdvanceToken` + byte path) with state merging, and `kTokenSet` contributions to `FillNextTokenBitmask`

## Test plan

- [x] Parser/printer roundtrip tests (5 tests)
- [x] Matcher accept_token tests (4 tests)  
- [x] Bitmask generation tests (4 tests)
- [x] Full regression suite: 1261 passed, 0 failed